### PR TITLE
Work around GoDaddy ERR_EMPTY_RESPONSE

### DIFF
--- a/unzipper.php
+++ b/unzipper.php
@@ -299,7 +299,7 @@ class Zipper {
   }
 }
 ?>
-
+<?php echo ""; /** Somewhy GoDaddy returns ERR_EMPTY_RESPONSE without this. */ ?>
 <!DOCTYPE html>
 <html>
 <head>


### PR DESCRIPTION
Anyone knows why the response is empty and could replace this with a proper fix, I'd be very glad. With this line it works fine. Remove it, and no response again, both in Chrome and Curl. Moreover not a single line is executed. Tried PHP 5.6 and 7.1, made sure display_errors is On and error_reporting is E_ALL. White screen of death again and again. Server log contains nothing related.