### PR TITLE
Feature: exclude leading directory when extracting

### DIFF
--- a/unzipper.php
+++ b/unzipper.php
@@ -239,6 +239,36 @@ class Unzipper {
     return $tmp_dir;
   }
 
+  /**
+   * Move all files and folders from one directory to another, but if source directory only contains a lonely folder it will be excluded.
+   *
+   * @param string $source
+   *   All files and folders will be moved from this directory.
+   * @param string $destination
+   *   All files and folders will be moved to this directory.
+   */
+  private static function moveFilesExcludingLeadingDir($source, $destination) {
+    $dir_content = array_values(array_diff(scandir($source), ['.', '..']));
+
+    // Check if source directory only contains a single folder
+    if (count($dir_content) == 1 && is_dir($source.'/'.$dir_content[0])) {
+      $from_dir = $source.'/'.$dir_content[0];
+      $dir_content = array_values(array_diff(scandir($from_dir), ['.', '..']));
+    }
+    else {
+      $from_dir = $source;
+    }
+
+    // Move all files and folders
+    foreach($dir_content as $item) {
+      rename($from_dir.'/'.$item, $destination.'/'.$item);
+    }
+
+    if ($from_dir != $source) {
+      rmdir($from_dir);
+    }
+  }
+
 }
 
 /**

--- a/unzipper.php
+++ b/unzipper.php
@@ -115,8 +115,10 @@ class Unzipper {
   /**
    * Decompress/extract a zip archive using ZipArchive.
    *
-   * @param $archive
-   * @param $destination
+   * @param string $archive
+   *   The archive name including file extension. E.g. my_archive.zip.
+   * @param string $destination
+   *   The relative destination path where to extract files.
    */
   public static function extractZipArchive($archive, $destination) {
     // Check if webserver supports unzipping.

--- a/unzipper.php
+++ b/unzipper.php
@@ -223,6 +223,22 @@ class Unzipper {
     }
   }
 
+  /**
+   * Create a temporary writable directory with a random name.
+   */
+  private static function createTmpDir() {
+    // Decide where to create temp directory
+    $dir = is_writeable('./') ? '.' : sys_get_temp_dir();
+
+    // Create a random temp directory name
+    do {
+      $tmp_dir = $dir.'/'.mt_rand();
+    }
+    while (!@mkdir($tmp_dir));
+
+    return $tmp_dir;
+  }
+
 }
 
 /**

--- a/unzipper.php
+++ b/unzipper.php
@@ -20,7 +20,8 @@ if (isset($_POST['dounzip'])) {
   // Check if an archive was selected for unzipping.
   $archive = isset($_POST['zipfile']) ? strip_tags($_POST['zipfile']) : '';
   $destination = isset($_POST['extpath']) ? strip_tags($_POST['extpath']) : '';
-  $unzipper->prepareExtraction($archive, $destination);
+  $exclude_leading_dir = isset($_POST['exclude_leading_dir']) ? true : false;
+  $unzipper->prepareExtraction($archive, $destination, $exclude_leading_dir);
 }
 
 if (isset($_POST['dozip'])) {
@@ -495,6 +496,9 @@ class Zipper {
     <label for="extpath">Extraction path (optional):</label>
     <input type="text" name="extpath" class="form-field" />
     <p class="info">Enter extraction path without leading or trailing slashes (e.g. "mypath"). If left empty current directory will be used.</p>
+    <label for="exclude_leading_dir">Do not include leading directory:</label>
+    <input type="checkbox" name="exclude_leading_dir" />
+    <p class="info">For archives made of only one single directory containing all files and folders. Check this checkbox to extract archive without including this single directory.</p>
     <input type="submit" name="dounzip" class="submit" value="Unzip Archive"/>
   </fieldset>
 


### PR DESCRIPTION
This pull request aims to add a new feature to unzipper. If an archive to be extracted only contains one single directory in its root, unzipper can now choose to only extract the content of this single directory and not include the directory itself in the extraction.

The feature is controlled by a checkbox added to the HTML.

I got this idea when trying to deploy WordPress on a new website. After extracting the zip file downloaded from wordpress.org I got a wordpress/ directory in my website root instead of the WordPress files and folders, which is not what I intended.

I tried many solutions to this problem and finally decided on the following:
- extract archive to a newly created empty temporary directory (tempdir) and move all files and folder from the tempdir to the real destination.
- if the tempdir only contains one single directory, move the content of said directory instead of the tempdir content.

It may seem like a better idea to extract each file from an archive directly to the destination folder, thereby not needing a tmpdir. But the only way I found to do this was by iterating over the archive files and using `copy("zip://archive.zip#path/to/file.txt")`. And this solution has serious performance problems with larger archives. Archives that can normally be extracted will instead be cancelled by the PHP max_execution_time.

The implemented solution is also easy to incorporate in any future additions to supported archive formats.

Feedback is welcome.